### PR TITLE
Bump min version_requirement for Puppet + deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Facette
 
-This module works only with Puppet 3.7+ with the future parser enabled or
+This module works only with Puppet 3.8.7 with the future parser enabled or
 Puppet 4.
 
 ## Module description

--- a/metadata.json
+++ b/metadata.json
@@ -15,26 +15,22 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": ">= 2015.2.0"
-    },
-    {
       "name": "puppet",
-      "version_requirement": ">= 3.7.3"
+      "version_requirement": ">= 3.8.7 < 4.0.0"
     }
   ],
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.0.0 <5.0.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     },
     {
       "name": "herculesteam/augeasproviders_shellvar",
-      "version_requirement": ">= 2.2.0 <3.0.0"
+      "version_requirement": ">= 2.2.1 < 3.0.0"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.0.0 <3.0.0"
+      "version_requirement": ">= 2.1.0 < 3.0.0"
     }
   ]
 }


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet versions

Bump dependencies to the minimum version that should work under
Puppet 4, based on the metadata

Also remove deprecated pe version_requirement field